### PR TITLE
Fix deployment on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 before_script:
   - curl https://faucet.ropsten.be/donate/0xc995206c20d29A428cc8535279525086b6e15C48
 deploy:
+  skip_cleanup: true
   provider: script
   script: yarn deploy
   on:


### PR DESCRIPTION
Do not clean before deploy, because that wipes out node_modules.
And we need node_modules for deployment.

Closes #40.