### PR TITLE
Update 'diff', a dependency of the old mocha that truffle ships with

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "prettier-standard": "^8.0.1",
     "standard": "^11.0.1"
   },
+  "resolutions": {
+    "diff": "^3.5.0"
+  },
   "scripts": {
     "test": "standard && lerna run test",
     "deploy": "lerna run deploy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,10 +3985,10 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-diff@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
-  integrity sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
+diff@3.3.1, diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"


### PR DESCRIPTION
Addresses vulnerability WS-2018-0590:

A vulnerability was found in diff before v3.5.0, the affected versions
of this package are vulnerable to Regular Expression Denial of Service
(ReDoS) attacks.